### PR TITLE
Fix enumBits overflow, unused import and dependabot branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    target-branch: 15
+    target-branch: 16-qpr2
   - package-ecosystem: gradle
     directory: "/"
     schedule:
       interval: daily
-    target-branch: 15
+    target-branch: 16-qpr2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.android.build.gradle.internal.utils.getBuildSrcPlugins
-
 plugins {
     id("com.android.application") version "9.0.0" apply false
     id("com.google.protobuf") version "0.9.5" apply false

--- a/generator/src/main/kotlin/ConfigGenerator.kt
+++ b/generator/src/main/kotlin/ConfigGenerator.kt
@@ -159,7 +159,7 @@ fun CompatConfig.Builder.changes_(list: List<CompatChange>) {
 fun <T : ProtocolMessageEnum> enumBits(bits: List<T>): Long {
     var v = 0L
     bits.forEach {
-        v = v or (1 shl it.number).toLong()
+        v = v or (1L shl it.number)
     }
     return v
 }


### PR DESCRIPTION
- Update `target-branch` in `.github/dependabot.yml` from `15` to `16-qpr2`
- Fix `enumBits` in `ConfigGenerator.kt` to shift a `Long` literal (`1L shl it.number`) instead of an `Int` (`1 shl it.number`), preventing silent integer overflow if any `CompatChange` enum value is ever ≥ 32
- Remove unused import of `com.android.build.gradle.internal.utils.getBuildSrcPlugins` from root `build.gradle.kts`