### PR TITLE
use directories instead of deprecated srcDir

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
 
     sourceSets.getByName("main") {
         manifest.srcFile("AndroidManifest.xml")
-        res.srcDir("res")
-        resources.srcDir("../app_compat_configs.pb")
+        res.directories.add("res")
+        resources.directories.add("../app_compat_configs.pb")
     }
 
     tasks.preBuild {


### PR DESCRIPTION
Compiling yields this warning: "fun srcDir(srcDir: Any): Any' is deprecated. Use `directories`
mutable set instead". This is due to
https://cs.android.com/android-studio/platform/tools/base/+/7e71ed5242853ed1889c556a260cbfc29d1d2ab4

Test: `./gradlew assembleRelease`, then opening APK to verify app_compat_configs.pb file is present in
same location as before, and loading onto device to verify config.